### PR TITLE
Made compatible for use with the esp8266 & esp32 boards

### DIFF
--- a/Adafruit_DAP_STM32.cpp
+++ b/Adafruit_DAP_STM32.cpp
@@ -274,8 +274,11 @@ bool Adafruit_DAP_STM32::verifyFlash(uint32_t addr, const uint8_t *data,
   uint8_t buf[4 * 1024];
 
   while (size) {
-    uint32_t const count = min(size, sizeof(buf));
-
+    #if defined(ESP8266) || defined(ESP32)
+      uint32_t const count = _min(size, sizeof(buf));
+    #else
+      uint32_t const count = min(size, sizeof(buf));
+    #endif
     dap_read_block(addr, buf, count);
 
     if (memcmp(data, buf, count))

--- a/Adafruit_DAP_nRF5x.cpp
+++ b/Adafruit_DAP_nRF5x.cpp
@@ -268,7 +268,11 @@ bool Adafruit_DAP_nRF5x::program(uint32_t addr, const uint8_t *buf,
 
   while (count) {
     uint8_t data[CHUNK_SIZE];
-    uint32_t bytes = min(count, CHUNK_SIZE);
+    #if defined(ESP8266) || defined(ESP32)
+      uint32_t bytes = _min(count, CHUNK_SIZE);
+    #else
+      uint32_t bytes = min(count, CHUNK_SIZE);
+    #endif
     bool hasdata = false;
 
     memset(data, 0xFF, CHUNK_SIZE);

--- a/dap_config.h
+++ b/dap_config.h
@@ -252,9 +252,10 @@ static inline void DAP_CONFIG_SETUP() {
   // pinMode(DAP_CONFIG_TDO_PIN, INPUT);
   // pinMode(DAP_CONFIG_nTRST_PIN, INPUT);
   pinMode(DAP_CONFIG_nRESET_PIN, INPUT);
-
-  pinMode(LED_BUILTIN, OUTPUT);
-  digitalWrite(LED_BUILTIN, HIGH);
+  #ifdef LED_BUILTIN
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, HIGH);
+  #endif
 }
 
 //-----------------------------------------------------------------------------
@@ -310,8 +311,10 @@ gpio_outset_bulk(PORTA, (1ul << CONFIG_DAP_nTRST));
 
 //-----------------------------------------------------------------------------
 static inline void DAP_CONFIG_LED(int index, int state) {
-  if (0 == index)
-    digitalWrite(LED_BUILTIN, !state);
+  #ifdef LED_BUILTIN
+    if (0 == index)
+      digitalWrite(LED_BUILTIN, !state);
+  #endif
 }
 
 #endif // _DAP_CONFIG_H_

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for DAP programming on ARM cortex microcontroller
 paragraph=Arduino library for DAP programming on ARM cortex microcontroller
 category=Other
 url=https://github.com/adafruit/Adafruit_DAP
-architectures=samd
+architectures=samd,esp32,esp8266
 depends=Adafruit SPIFlash, SdFat - Adafruit Fork, Adafruit TinyUSB Library, SD


### PR DESCRIPTION
With minor changes, I was able to make this nice library compatible for use with the esp8266 & esp32 boards.

I tested and was able to successfully update my samd21 board from both mentioned esp boards.

Not all boards have the LED_BUILTIN defined. I worked around this by using a precompiler statement. #ifdef LED_BUILTIN
If you would like to see a different solution please let me know.