### PR TITLE
P2 - Made compatible for use with the esp8266 & esp32 boards

### DIFF
--- a/Adafruit_DAP_nRF5x.cpp
+++ b/Adafruit_DAP_nRF5x.cpp
@@ -268,7 +268,7 @@ bool Adafruit_DAP_nRF5x::program(uint32_t addr, const uint8_t *buf,
 
   while (count) {
     uint8_t data[CHUNK_SIZE];
-    uint32_t bytes = min(count, (size_t) CHUNK_SIZE);
+    uint32_t bytes = min(count, (uint32_t) CHUNK_SIZE);
     bool hasdata = false;
 
     memset(data, 0xFF, CHUNK_SIZE);

--- a/Adafruit_DAP_nRF5x.cpp
+++ b/Adafruit_DAP_nRF5x.cpp
@@ -268,7 +268,7 @@ bool Adafruit_DAP_nRF5x::program(uint32_t addr, const uint8_t *buf,
 
   while (count) {
     uint8_t data[CHUNK_SIZE];
-    uint32_t bytes = min(count, CHUNK_SIZE);
+    uint32_t bytes = min(count, (size_t) CHUNK_SIZE);
     bool hasdata = false;
 
     memset(data, 0xFF, CHUNK_SIZE);

--- a/dap_config.h
+++ b/dap_config.h
@@ -252,9 +252,10 @@ static inline void DAP_CONFIG_SETUP() {
   // pinMode(DAP_CONFIG_TDO_PIN, INPUT);
   // pinMode(DAP_CONFIG_nTRST_PIN, INPUT);
   pinMode(DAP_CONFIG_nRESET_PIN, INPUT);
-
-  pinMode(LED_BUILTIN, OUTPUT);
-  digitalWrite(LED_BUILTIN, HIGH);
+  #ifdef LED_BUILTIN
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, HIGH);
+  #endif
 }
 
 //-----------------------------------------------------------------------------
@@ -310,8 +311,10 @@ gpio_outset_bulk(PORTA, (1ul << CONFIG_DAP_nTRST));
 
 //-----------------------------------------------------------------------------
 static inline void DAP_CONFIG_LED(int index, int state) {
-  if (0 == index)
-    digitalWrite(LED_BUILTIN, !state);
+  #ifdef LED_BUILTIN
+    if (0 == index)
+      digitalWrite(LED_BUILTIN, !state);
+  #endif
 }
 
 #endif // _DAP_CONFIG_H_

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for DAP programming on ARM cortex microcontroller
 paragraph=Arduino library for DAP programming on ARM cortex microcontroller
 category=Other
 url=https://github.com/adafruit/Adafruit_DAP
-architectures=samd
+architectures=samd,esp32,esp8266
 depends=Adafruit SPIFlash, SdFat - Adafruit Fork, Adafruit TinyUSB Library, SD


### PR DESCRIPTION
Part2: With the suggestions made by @ladyada in [Part1](https://github.com/adafruit/Adafruit_DAP/pull/19#discussion_r616979359)

With minor changes, I was able to make this nice library compatible for use with the esp8266 & esp32 boards.

I tested and was able to successfully update my samd21 board from both mentioned esp boards and my Arduini MKR WiFi 1010

Not all boards have the LED_BUILTIN defined. Users can easily change this in the examples! In the library I using a precompiler statement #ifdef LED_BUILTIN