### PR TITLE
fix build error for esp32-c3

### DIFF
--- a/Adafruit_DAP.cpp
+++ b/Adafruit_DAP.cpp
@@ -516,7 +516,7 @@ uint32_t Adafruit_DAP::computeFlashCRC32(uint32_t addr, uint32_t size) {
   uint8_t buf[512];
 
   while(size) {
-    uint32_t count = min(size, sizeof(buf));
+    uint32_t count = min(size, (uint32_t) sizeof(buf));
 
     dap_read_block(addr, buf, (int) count);
     crc32.add(buf, count);

--- a/Adafruit_DAP_STM32.cpp
+++ b/Adafruit_DAP_STM32.cpp
@@ -289,7 +289,7 @@ bool Adafruit_DAP_STM32::verifyFlash(uint32_t addr, const uint8_t *data,
   uint8_t buf[4 * 1024];
 
   while (size) {
-    uint32_t const count = min(size, sizeof(buf));
+    uint32_t const count = min(size, (uint32_t) sizeof(buf));
 
     dap_read_block(addr, buf, count);
 


### PR DESCRIPTION
This pull request fixes the issue, that the Adafruit_DAP library cannot be build on the esp32-c3 target. The compiler gives the error, that there is no min(long unsigned int, unsigned int) function. A cast to uint32_t and so here min(long unsigned int, long unsigned int) fixes this issue. I have successfully tested it with an esp32-c3 and a samd21 mcu.